### PR TITLE
Resolve null-reference warnings (CS8601)

### DIFF
--- a/Source/Common/ScribeLike.cs
+++ b/Source/Common/ScribeLike.cs
@@ -17,3 +17,4 @@ public static class ScribeLike
         public abstract void Look<T>(ref T value, string label, T defaultValue, bool forceSave);
     }
 }
+


### PR DESCRIPTION
[CS8601 - Possible null reference assignment](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-null-assigned-to-a-nonnullable-reference)

We can see from the decompiled binaries whether a project has the `<Nullable>enable</Nullable>` attribute set:  
<img width="278" height="123" alt="image" src="https://github.com/user-attachments/assets/f55ea5df-0131-4960-ae5c-69c5fda9a969" />  
Like [`Common.csproj`](https://github.com/rwmt/Multiplayer/blob/dev/Source/Common/Common.csproj#L6C5-L6C32) does.

Or the class has the `#nullable enable` directive:  
<img width="272" height="125" alt="image" src="https://github.com/user-attachments/assets/2afa7e0b-ec74-4067-85d9-56a205d9b58a" />  
Like [`Layouter.cs`](https://github.com/rwmt/Multiplayer/blob/dev/Source/Client/UI/Layouter.cs#L9C1-L9C17)

We can then infer that something like `Verse.Scribe_Values` does not use explicit nullable flags:  
<img width="917" height="190" alt="image" src="https://github.com/user-attachments/assets/efcf3208-e88c-477e-8644-3dade82b12ba" />  
Which means that all reference types are nullable. Plus it makes null checks a few lines later.

This is all to justify enabling 